### PR TITLE
Idiomatic change: using an int like a bool

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -566,7 +566,7 @@ func validateSequence(packetLen int, prefixByte uint8, sequence uint64, readPack
 
 	// replay protection (optional)
 	if replayProtection != nil && PacketType(packetType) >= ConnectionKeepAlive {
-		if replayProtection.AlreadyReceived(sequence) == 1 {
+		if replayProtection.AlreadyReceived(sequence) {
 			v := strconv.FormatUint(sequence, 10)
 			return errors.New("ignored connection payload packet. sequence " + v + " already received (replay protection)")
 		}

--- a/replay_protection.go
+++ b/replay_protection.go
@@ -21,13 +21,13 @@ func (r *ReplayProtection) Reset() {
 }
 
 // Tests that the sequence has not already been recv'd, adding it to the buffer if it's new.
-func (r *ReplayProtection) AlreadyReceived(sequence uint64) int {
+func (r *ReplayProtection) AlreadyReceived(sequence uint64) bool {
 	if sequence&(uint64(1<<63)) != 0 {
-		return 0
+		return false
 	}
 
 	if sequence+REPLAY_PROTECTION_BUFFER_SIZE <= r.MostRecentSequence {
-		return 1
+		return true
 	}
 
 	if sequence > r.MostRecentSequence {
@@ -38,15 +38,15 @@ func (r *ReplayProtection) AlreadyReceived(sequence uint64) int {
 
 	if r.ReceivedPacket[index] == 0xFFFFFFFFFFFFFFFF {
 		r.ReceivedPacket[index] = sequence
-		return 0
+		return false
 	}
 
 	if r.ReceivedPacket[index] >= sequence {
-		return 1
+		return true
 	}
 
 	r.ReceivedPacket[index] = sequence
-	return 0
+	return false
 }
 
 func clearPacketBuffer(packets []uint64) {

--- a/replay_protection_test.go
+++ b/replay_protection_test.go
@@ -15,7 +15,7 @@ func TestReplayProtection_Reset(t *testing.T) {
 
 func TestReplayProtection(t *testing.T) {
 	r := NewReplayProtection()
-	for i := 0; i < 2; i+=1 {
+	for i := 0; i < 2; i += 1 {
 		r.Reset()
 		if r.MostRecentSequence != 0 {
 			t.Fatalf("sequence was not 0")
@@ -23,7 +23,7 @@ func TestReplayProtection(t *testing.T) {
 
 		// sequence numbers with high bit set should be ignored
 		sequence := uint64(1 << 63)
-		if r.AlreadyReceived(sequence) != 0 {
+		if r.AlreadyReceived(sequence) {
 			t.Fatalf("sequence numbers with high bit set should be ignored")
 		}
 
@@ -33,32 +33,32 @@ func TestReplayProtection(t *testing.T) {
 
 		// the first time we receive packets, they should not be already received
 		maxSequence := uint64(REPLAY_PROTECTION_BUFFER_SIZE * 4)
-		for sequence = 0; sequence < maxSequence; sequence+=1 {
-			if r.AlreadyReceived(sequence) != 0 {
+		for sequence = 0; sequence < maxSequence; sequence += 1 {
+			if r.AlreadyReceived(sequence) {
 				t.Fatalf("the first time we receive packets, they should not be already received")
 			}
 		}
 
 		// old packets outside buffer should be considered already received
-		if r.AlreadyReceived(0) != 1 {
+		if !r.AlreadyReceived(0) {
 			t.Fatalf("old packets outside buffer should be considered already received")
 		}
 
 		// packets received a second time should be flagged already received
-		for sequence = maxSequence - 10; sequence < maxSequence; sequence+=1 {
-			if r.AlreadyReceived(sequence) != 1 {
+		for sequence = maxSequence - 10; sequence < maxSequence; sequence += 1 {
+			if !r.AlreadyReceived(sequence) {
 				t.Fatalf("packets received a second time should be flagged already received")
 			}
 		}
 
 		// jumping ahead to a much higher sequence should be considered not already received
-		if r.AlreadyReceived(maxSequence+REPLAY_PROTECTION_BUFFER_SIZE) != 0 {
+		if r.AlreadyReceived(maxSequence + REPLAY_PROTECTION_BUFFER_SIZE) {
 			t.Fatalf("jumping ahead to a much higher sequence should be considered not already received")
 		}
 
 		// old packets should be considered already received
-		for sequence = 0; sequence < maxSequence; sequence+=1 {
-			if r.AlreadyReceived(sequence) != 1 {
+		for sequence = 0; sequence < maxSequence; sequence += 1 {
+			if !r.AlreadyReceived(sequence) {
 				t.Fatalf("old packets should be considered already received")
 			}
 		}


### PR DESCRIPTION
I was very lucky spotting this one.

NOTE: There's a bunch of spacing changes introduced by `gofmt`.