### PR TITLE
Feature/lint all the things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+    - 1.9
+
+install:
+    - make install-tools
+
+script:
+    - make ci-check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+PACKAGES=$(shell go list ./...)
+
+test:
+	go test -v ./...
+
+install-tools:
+	go get github.com/GeertJohan/fgt
+	go get golang.org/x/tools/cmd/goimports
+	#go get github.com/golang/lint/golint
+	#go get github.com/mattn/goveralls
+	#go get honnef.co/go/tools/cmd/gosimple
+	#go get mvdan.cc/interfacer
+	#go get github.com/kisielk/errcheck
+	#go get honnef.co/go/tools/cmd/staticcheck
+	#go get golang.org/x/tools/cmd/cover
+
+lint:
+	fgt go fmt ./...
+	fgt goimports -w .
+	#fgt golint ./...
+	#fgt go vet ./...
+	#fgt gosimple ./...
+	#fgt interfacer ./...
+	#fgt errcheck ./...
+	#staticcheck ./...
+
+ci-check: lint test

--- a/connect_token_private_test.go
+++ b/connect_token_private_test.go
@@ -15,7 +15,7 @@ func TestConnectTokenPrivate(t *testing.T) {
 
 	currentTimestamp := uint64(time.Now().Unix())
 	expireTimestamp := uint64(currentTimestamp + TEST_CONNECT_TOKEN_EXPIRY)
-	timeoutSeconds := (int32) (10)
+	timeoutSeconds := (int32)(10)
 
 	userData, err := RandomBytes(USER_DATA_BYTES)
 	if err != nil {

--- a/crypto.go
+++ b/crypto.go
@@ -2,6 +2,7 @@ package netcode
 
 import (
 	"crypto/rand"
+
 	"golang.org/x/crypto/chacha20poly1305"
 )
 

--- a/examples/c_client/c_client.go
+++ b/examples/c_client/c_client.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"flag"
-	"github.com/wirepair/netcode"
 	"log"
 	"math/rand"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/wirepair/netcode"
 )
 
 const (

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -4,13 +4,14 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"flag"
-	"github.com/wirepair/netcode"
 	"log"
 	"math/rand"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/wirepair/netcode"
 )
 
 var totalPayloadCount uint64


### PR DESCRIPTION
It's common in the Go landscape to pass linters to the code to increase its quality. The typical ones are `fmt`, `lint` and `vet` but there are some others that are great too.

This PR adds support for some of them, even there are just enabled `fmt` and `goimports` for now because the rest will take a lot of work to fix because of naming and comments for e.g. So if this one is merged I will work on the rest. 

For me, this is a way to start digging into the project, since I've not looked at what all the code does _yet_ but that's not needed to make a lot of things go-idiomatic.

Tests and linters should be thrown by a CI (Continuous Integration) service to make sure the code changes comply with the rules. That's why I've added TravisCI support (free for open source projects), but I think something must be configured from the repository owner. 