### PR TITLE
fixed wrong fmt verbs

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -30,7 +30,7 @@ func TestBuffer_Copy(t *testing.T) {
 	}
 
 	if string(data) != "abcdefghij" {
-		t.Fatalf("error expeced: %s got %d\n", "abcdefghij", string(data))
+		t.Fatalf("error expeced: %v got %v\n", "abcdefghij", string(data))
 	}
 }
 

--- a/connect_token_private_test.go
+++ b/connect_token_private_test.go
@@ -102,7 +102,7 @@ func testCompareAddrs(addr1, addr2 net.UDPAddr, t *testing.T) {
 	}
 
 	if addr1.Port != addr2.Port {
-		t.Fatalf("server ports did not match: expected %s got %s\n", addr1.Port, addr2.Port)
+		t.Fatalf("server ports did not match: expected %v got %v\n", addr1.Port, addr2.Port)
 	}
 
 }

--- a/connect_token_shared.go
+++ b/connect_token_shared.go
@@ -115,7 +115,7 @@ func (shared *sharedTokenData) WriteShared(buffer *Buffer) error {
 	for _, addr := range shared.ServerAddrs {
 		host, port, err := net.SplitHostPort(addr.String())
 		if err != nil {
-			return fmt.Errorf("invalid port for host: %s", addr)
+			return fmt.Errorf("invalid port for host: %v", addr)
 		}
 
 		parsed := net.ParseIP(host)

--- a/connect_token_test.go
+++ b/connect_token_test.go
@@ -48,19 +48,19 @@ func TestConnectToken(t *testing.T) {
 	}
 
 	if inToken.ProtocolId != outToken.ProtocolId {
-		t.Fatalf("ProtocolId did not match expected: %s got: %s\n", inToken.ProtocolId, outToken.ProtocolId)
+		t.Fatalf("ProtocolId did not match expected: %v got: %v\n", inToken.ProtocolId, outToken.ProtocolId)
 	}
 
 	if inToken.CreateTimestamp != outToken.CreateTimestamp {
-		t.Fatalf("CreateTimestamp did not match expected: %s got: %s\n", inToken.CreateTimestamp, outToken.CreateTimestamp)
+		t.Fatalf("CreateTimestamp did not match expected: %v got: %v\n", inToken.CreateTimestamp, outToken.CreateTimestamp)
 	}
 
 	if inToken.ExpireTimestamp != outToken.ExpireTimestamp {
-		t.Fatalf("ExpireTimestamp did not match expected: %s got: %s\n", inToken.ExpireTimestamp, outToken.ExpireTimestamp)
+		t.Fatalf("ExpireTimestamp did not match expected: %v got: %v\n", inToken.ExpireTimestamp, outToken.ExpireTimestamp)
 	}
 
 	if inToken.Sequence != outToken.Sequence {
-		t.Fatalf("Sequence did not match expected: %s got: %s\n", inToken.Sequence, outToken.Sequence)
+		t.Fatalf("Sequence did not match expected: %v got: %v\n", inToken.Sequence, outToken.Sequence)
 	}
 
 	testCompareTokens(inToken, outToken, t)


### PR DESCRIPTION
I just changed them all to `v` so you don't have to care anymore. 