### PR TITLE
Bind listen IP address to 0.0.0.0

### DIFF
--- a/server.go
+++ b/server.go
@@ -106,7 +106,12 @@ func (s *Server) Init() error {
 func (s *Server) Listen() error {
 	s.running = true
 
-	if err := s.serverConn.Listen(s.serverAddr); err != nil {
+	addr := &net.UDPAddr{
+		Port: s.serverAddr.Port,
+		IP:   net.ParseIP("0.0.0.0"),
+	}
+
+	if err := s.serverConn.Listen(addr); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Bind listen IP address to 0.0.0.0 so that external address can be provided when creating server so it matches the connect token's whitelist. This is required in environments where the server has both an internal and an external IP address, like on Google Compute Engine.

This addresses issue #13 