### PR TITLE
Remove server time parameter in cases where it is not needed

### DIFF
--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -131,7 +131,7 @@ func serveLoop(closeCh chan struct{}, ctrlCloseCh chan os.Signal, index int) {
 		// do simulation/process payload packets
 
 		// send payloads to clients
-		serv.SendPayloads(payload, serverTime)
+		serv.SendPayloads(payload)
 
 		time.Sleep(deltaTime)
 		serverTime += deltaTime.Seconds()

--- a/server.go
+++ b/server.go
@@ -112,21 +112,21 @@ func (s *Server) Listen() error {
 	return nil
 }
 
-func (s *Server) SendPayloads(payloadData []byte, serverTime float64) {
+func (s *Server) SendPayloads(payloadData []byte) {
 	if !s.running {
 		return
 	}
-	s.clientManager.sendPayloads(payloadData, serverTime)
+	s.clientManager.sendPayloads(payloadData, s.serverTime)
 }
 
 // Sends the payload to the client specified by their clientId.
-func (s *Server) SendPayloadToClient(clientId uint64, payloadData []byte, serverTime float64) error {
+func (s *Server) SendPayloadToClient(clientId uint64, payloadData []byte) error {
 	clientIndex, err := s.GetClientIndexByClientId(clientId)
 	if err != nil {
 		return err
 	}
 
-	s.clientManager.sendPayloadToInstance(clientIndex, payloadData, serverTime)
+	s.clientManager.sendPayloadToInstance(clientIndex, payloadData, s.serverTime)
 	return nil
 }
 
@@ -153,13 +153,13 @@ DONE:
 }
 
 // Disconnects a single client via the specified clientId
-func (s *Server) DisconnectClient(clientId uint64, sendDisconnect bool, serverTime float64) error {
+func (s *Server) DisconnectClient(clientId uint64, sendDisconnect bool) error {
 	clientIndex, err := s.GetClientIndexByClientId(clientId)
 	if err != nil {
 		return err
 	}
 
-	s.clientManager.DisconnectClient(clientIndex, sendDisconnect, serverTime)
+	s.clientManager.DisconnectClient(clientIndex, sendDisconnect, s.serverTime)
 	return nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-type SendFunc func(serv *Server, payload []byte, serverTime float64)
+type SendFunc func(serv *Server, payload []byte)
 
 func TestServerListen(t *testing.T) {
 	port := 40000
@@ -25,18 +25,18 @@ func TestServerSendPayloadToClient(t *testing.T) {
 }
 
 // Tests sending payloads to all connected clients
-func testSendFunc(serv *Server, payload []byte, serverTime float64) {
+func testSendFunc(serv *Server, payload []byte) {
 	// send payloads to clients
-	serv.SendPayloads(payload, serverTime)
+	serv.SendPayloads(payload)
 }
 
 // Tests sending to individual clients via their ClientIds
-func testSendToClientFunc(serv *Server, payload []byte, serverTime float64) {
+func testSendToClientFunc(serv *Server, payload []byte) {
 	// do simulation/process payload packets
 	clientIds := serv.GetConnectedClientIds()
 	if len(clientIds) > 0 {
 		for _, clientId := range clientIds {
-			serv.SendPayloadToClient(clientId, payload, serverTime)
+			serv.SendPayloadToClient(clientId, payload)
 		}
 	}
 }
@@ -85,7 +85,7 @@ func runTestServer(port int, sendFunc SendFunc, doneCh chan struct{}, t *testing
 
 		// send payloads to clients
 		//sendFunc(serv, payload, serverTime)
-		serv.SendPayloads(payload, serverTime)
+		serv.SendPayloads(payload)
 
 		time.Sleep(deltaTime)
 		serverTime += deltaTime.Seconds()


### PR DESCRIPTION
In some cases methods on `*Server` were expecting a `serverTime` parameter, but the server time is already available in the struct.

This addresses issue #6 